### PR TITLE
CORS 에러 해결을 위한 프록시 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "last 1 safari version"
     ]
   },
+  "proxy": "https://www.waffle-minkyu.shop",
   "devDependencies": {
     "prettier": "2.4.1"
   }

--- a/src/component/TestComponent/TestLogIn/TestLogIn.tsx
+++ b/src/component/TestComponent/TestLogIn/TestLogIn.tsx
@@ -1,6 +1,6 @@
 import "./TestLogIn.css";
 import React, { useState } from "react";
-import { AxiosResponse } from "axios";
+import axios, { AxiosResponse } from "axios";
 import request from "../../../API/API";
 
 const TestLogIn = () => {
@@ -16,8 +16,9 @@ const TestLogIn = () => {
   const tryTestLogin = (usernameInput: string, passwordInput: string) => {
     return (event: React.SyntheticEvent) => {
       event.preventDefault(); //submit 시 새로고침 방지
-      request
-        .post<LoginInputType, AxiosResponse>("user/login", {
+      // request
+      axios
+        .post<LoginInputType, AxiosResponse>("/user/login/", {
           username: usernameInput,
           password: passwordInput,
         })

--- a/src/component/TestComponent/TestSignup/TestSignup.tsx
+++ b/src/component/TestComponent/TestSignup/TestSignup.tsx
@@ -1,6 +1,6 @@
 import "./TestSignup.css";
 import React, { useState } from "react";
-import { AxiosResponse } from "axios";
+import axios, { AxiosResponse } from "axios";
 import request from "../../../API/API";
 
 const TestSignup = () => {
@@ -30,8 +30,8 @@ const TestSignup = () => {
   ) => {
     return (event: React.SyntheticEvent) => {
       event.preventDefault(); //submit 시 새로고침 방지
-      request
-        .post<SignupInputType, AxiosResponse>("/user/signup", {
+      axios
+        .post<SignupInputType, AxiosResponse>("/user/signup/", {
           username: usernameInput,
           password: passwordInput,
           email: emailInput,


### PR DESCRIPTION
일단 빌드랑 재배포는 안하고 로컬 환경에서만 확인할 수 있게 바꿨습니다
- API.js의 request 안 쓰고 일단 axios 바로 사용하는 형식인데 다른 방식 있을 지 생각해봅시다
- 아이디: test, 비밀번호: test로 테스트 계정 만들었습니다

[요거 참고](https://velog.io/@ezae/React-build%EB%B0%B0%ED%8F%AC-%ED%9B%84-api-response-%EB%AC%B8%EC%A0%9C)해서 빌드 시 프록시 말고 일반 연결 세팅 되도록 해야할 거 같네요
관련 내용은 슬랙에 정리해 놓았슴다