### PR TITLE
게시판에서 게시글 미리보기

### DIFF
--- a/src/component/Home/Board/BoardView/BoardView.tsx
+++ b/src/component/Home/Board/BoardView/BoardView.tsx
@@ -1,37 +1,52 @@
 import { useEffect, useState } from "react";
 import { getBoardDetailDummy } from "../../../../dummy/get-dummy";
 import { Link } from "react-router-dom";
-
+import request from "../../../../API/API";
+import axios from "axios";
 interface BoardParams {
   match: {
     path: string;
   };
 }
 
-interface boardDetailDummy {
-  id: string;
-  name: string;
-  data: boardDetailDummyItem[];
+interface boardDetail {
+  count: number;
+  next: string;
+  previous: string;
+  results: boardDetailItem[];
 }
 
-interface boardDetailDummyItem {
-  id: string;
+interface boardDetailItem {
+  board: string;
   writer: string;
   title: string;
   content: string;
+  id: number;
+  tags: string[];
 }
 
 const BoardView = ({ match }: BoardParams) => {
-  const [boardDetail, setBoardDetail] = useState<boardDetailDummy>({
-    id: "",
-    name: "",
-    data: [],
+  const [boardDetail, setBoardDetail] = useState<boardDetail>({
+    count: 0,
+    next: "",
+    previous: "",
+    results: [],
   });
   const [showForm, setShowForm] = useState<boolean>(false);
 
-  useEffect(() => {
-    setBoardDetail(getBoardDetailDummy(match.path.slice(1)));
-  }, [setBoardDetail, match.path]);
+  const getBoardDetail = () => {
+    request
+      .get(`/post/?board=${match.path.slice(1)}`)
+      .then((response) => {
+        console.log(response.data);
+        setBoardDetail(response.data);
+      })
+      .catch(() => {
+        console.log("게시글 리스트 불러오기 실패!"); //테스트용
+      });
+  };
+
+  useEffect(getBoardDetail, [setBoardDetail, match.path]);
 
   const openWrite = () => setShowForm(!showForm);
 
@@ -91,10 +106,11 @@ const BoardView = ({ match }: BoardParams) => {
           새 글을 작성해주세요!
         </button>
       )}
+
       <ul className="BoardView__list">
-        {boardDetail.data.map((item) => (
+        {boardDetail.results.map((item) => (
           <li key={item.id} className="BoardView__item">
-            <Link to={`${boardDetail.id}/${item.id}`}>
+            <Link to={`${match.path.slice(1)}/1`}>
               <div className={"wrapper"}>
                 <h2 className={"medium"}>{item.title}</h2> <br />{" "}
                 <p className={"small"}>{item.content}</p>

--- a/src/component/Home/Board/BoardView/BoardView.tsx
+++ b/src/component/Home/Board/BoardView/BoardView.tsx
@@ -107,18 +107,24 @@ const BoardView = ({ match }: BoardParams) => {
         </button>
       )}
 
-      <ul className="BoardView__list">
-        {boardDetail.results.map((item) => (
-          <li key={item.id} className="BoardView__item">
-            <Link to={`${match.path.slice(1)}/1`}>
-              <div className={"wrapper"}>
-                <h2 className={"medium"}>{item.title}</h2> <br />{" "}
-                <p className={"small"}>{item.content}</p>
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {boardDetail.results.length == 0 ? (
+        <ul className="BoardView__list">
+          <li className="BoardView__noItem">아직 글이 없습니다.</li>
+        </ul>
+      ) : (
+        <ul className="BoardView__list">
+          {boardDetail.results.map((item) => (
+            <li key={item.id} className="BoardView__item">
+              <Link to={`${match.path.slice(1)}/1`}>
+                <div className={"wrapper"}>
+                  <h2 className={"medium"}>{item.title}</h2> <br />
+                  <p className={"small"}>{item.content}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </>
   );
 };

--- a/src/component/Home/Board/BoardView/BoardView.tsx
+++ b/src/component/Home/Board/BoardView/BoardView.tsx
@@ -38,7 +38,6 @@ const BoardView = ({ match }: BoardParams) => {
     request
       .get(`/post/?board=${match.path.slice(1)}`)
       .then((response) => {
-        console.log(response.data);
         setBoardDetail(response.data);
       })
       .catch(() => {
@@ -115,7 +114,7 @@ const BoardView = ({ match }: BoardParams) => {
         <ul className="BoardView__list">
           {boardDetail.results.map((item) => (
             <li key={item.id} className="BoardView__item">
-              <Link to={`${match.path.slice(1)}/1`}>
+              <Link to={`${match.path.slice(1)}/${item.id}`}>
                 <div className={"wrapper"}>
                   <h2 className={"medium"}>{item.title}</h2> <br />
                   <p className={"small"}>{item.content}</p>

--- a/src/component/Home/PostView/PostView.tsx
+++ b/src/component/Home/PostView/PostView.tsx
@@ -10,7 +10,7 @@ interface PostViewParams {
   };
 }
 
-interface boardDetailDummyItem {
+interface BoardDetailDummyItem {
   id: string;
   writer: string;
   title: string;
@@ -18,7 +18,7 @@ interface boardDetailDummyItem {
 }
 
 const PostView = ({ match }: PostViewParams) => {
-  const [postDetail, setPostDetail] = useState<boardDetailDummyItem>({
+  const [postDetail, setPostDetail] = useState<BoardDetailDummyItem>({
     id: "",
     writer: "",
     title: "",


### PR DESCRIPTION
- 한 것

BoardView에서 게시글들을 서버에서 불러와 볼 수 있습니다. 아직 페이지네이션은 적용되어있지 않습니다!

-해야할 것

  현재 게시글을 클릭하면 해당 post의 id 주소로 이동해야합니다. 아직은 dummyData 사용중이고요. 그런데 아직은 페이지네이션 이 되어있지않아서 괜찮지만, 나중에 페이지네이션을 했을 때 postView의 내용을 어떻게 불러와야할지 고민입니다. 현재는 주소 query의 파라미터에서 id를 찾는 방식입니다. 찾는 id가 나올때까지 next pagination을 계속호출할 수도 없기때문에 postView를 boardView의 하위 컴포넌트로 넣는다는 식의 조정이 필요할 것 같습니다!!


