### PR TITLE
게시글 Link 절대경로로 수정

### DIFF
--- a/src/component/MainPage/Home/BoardView/BoardView.tsx
+++ b/src/component/MainPage/Home/BoardView/BoardView.tsx
@@ -31,6 +31,7 @@ const BoardView = () => {
 
   useEffect(() => {
     getPostWithPage(Number(pageNum));
+    console.log(params.boardId);
   }, [params]);
 
   const getPostWithPage = (page: number) => {
@@ -71,7 +72,7 @@ const BoardView = () => {
           <ul className="BoardView__list">
             {postList.results.map((item) => (
               <li key={item.id} className="BoardView__item">
-                <Link to={`${params.boardId}/${item.id}`}>
+                <Link to={`/${params.boardId}/${item.id}`}>
                   <div className={"wrapper"}>
                     <h2 className={"medium"}>{item.title}</h2> <br />
                     <p className={"small"}>{item.content}</p>


### PR DESCRIPTION
오... 리액트 라우터에서 Link에다 to 프롭 전달할 때 맨 앞에 "/"를 빼먹으면 상대경로로 보내진다는 놀라운 사실... 알아버렸습니다...

__커밋은 단 하나의 / 추가__