### PR TITLE
Fix/comment

### DIFF
--- a/src/component/MainPage/Home/PostView/Comment/Comment.tsx
+++ b/src/component/MainPage/Home/PostView/Comment/Comment.tsx
@@ -48,7 +48,7 @@ const Comment = ({ writer }: commentProps) => {
   }, []);
 
   const writeComment = (postId: number, input: CommentInputType) => {
-    if (!input.content) {
+    if (!input.content || input.content.replace(/\s|　/gi, "") === "") {
       window.alert("내용을 입력해주세요.");
       return;
     }

--- a/src/component/MainPage/Home/PostView/Comment/Comment.tsx
+++ b/src/component/MainPage/Home/PostView/Comment/Comment.tsx
@@ -87,6 +87,7 @@ const Comment = ({ writer }: commentProps) => {
     if (window.confirm("이 댓글에 공감하십니까?")) {
       postCommentVoteAPI(comment.id).then((response) => {
         console.log(response);
+        getComment();
         if (!response.is_success) {
           if (response.error_code === 1) {
             window.alert("이미 공감한 댓글입니다.");
@@ -173,9 +174,9 @@ const Comment = ({ writer }: commentProps) => {
               <div key={reply.id} className={"wrapperReply"}>
                 {item.nickname === "익명(글쓴이)" ||
                 item.nickname === writer ? (
-                  <h2 className={"medium_bold_writer"}>{item.nickname}</h2>
+                  <h2 className={"medium_bold_writer"}>{reply.nickname}</h2>
                 ) : (
-                  <h2 className={"medium_bold"}>{item.nickname}</h2>
+                  <h2 className={"medium_bold"}>{reply.nickname}</h2>
                 )}
                 <ul className={"status"}>
                   <li

--- a/src/component/MainPage/Home/PostView/Comment/Comment.tsx
+++ b/src/component/MainPage/Home/PostView/Comment/Comment.tsx
@@ -118,7 +118,7 @@ const Comment = ({ writer }: commentProps) => {
         {commentList.map((item) => (
           <li key={item.id} className={"Comment__item"}>
             <div className={"wrapper"}>
-              {item.nickname === "익명(글쓴이)" || item.nickname === writer ? (
+              {item.user_type === "글쓴이" ? (
                 <h2 className={"medium_bold_writer"}>{item.nickname}</h2>
               ) : (
                 <h2 className={"medium_bold"}>{item.nickname}</h2>
@@ -172,8 +172,7 @@ const Comment = ({ writer }: commentProps) => {
             </div>
             {item.replys.map((reply) => (
               <div key={reply.id} className={"wrapperReply"}>
-                {item.nickname === "익명(글쓴이)" ||
-                item.nickname === writer ? (
+                {reply.user_type === "글쓴이" ? (
                   <h2 className={"medium_bold_writer"}>{reply.nickname}</h2>
                 ) : (
                   <h2 className={"medium_bold"}>{reply.nickname}</h2>

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -83,6 +83,7 @@ export interface CommentItemType {
   is_mine: boolean;
   is_deleted: boolean;
   head_comment: number | null;
+  user_type: string;
   replys: CommentItemType[];
 }
 


### PR DESCRIPTION
댓글에 있었던 이슈들 모두 해결했습니다.

1. 대댓글 글쓴이가 제대로 표시되지 않던 이슈

2. 공감 눌렀을 시 바로 리렌더 되도록
 - 일단 공감버튼 누르면 getComment()로 아예 댓글을 모조리 가져오는 방식으로 했습니다. 실제 에타에서는 다른 댓글과 관계없이 공감에 성공하면 그냥 숫자에 +1을 해줍니다. 제가 구현한 방식은 새로고침을 안해도 공감만 누르면 바로 현재 공감 수가 불러와지지만, 한편으로는 불필요한 요청일 것 같기도 합니다. 

 3. 공백 입력 필터링
- 이 점은 post 쓸 때도 적용이 필요합니다! 

4. 쓰니를 user_type으로 구별하도록 함. 
- 나중에 게시판 관리자나 다른 user_type을 추가할 일이 생기면 편할 것 같아서 미리 바꿨습니다.